### PR TITLE
Fix UI label linkage and use Vite via node

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
+    "dev": "node node_modules/vite/bin/vite.js",
+    "build": "node node_modules/vite/bin/vite.js build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "node node_modules/vite/bin/vite.js preview"
   },
   "dependencies": {
     "chroma-js": "^3.1.2",

--- a/src/ColourInputForm.jsx
+++ b/src/ColourInputForm.jsx
@@ -87,11 +87,12 @@ function ColourInputForm() {
         <h2>Define Your Palette</h2>
 
         <div style={{ marginBottom: '2rem' }}>
-          <label>
+          <label htmlFor="backgroundColour">
             <strong>Default Background Colour</strong>
           </label>
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             <input
+              id="backgroundColour"
               type="color"
               value={backgroundColour}
               onChange={(e) => setBackgroundColour(e.target.value)}

--- a/src/StyleGuidePreview.jsx
+++ b/src/StyleGuidePreview.jsx
@@ -8,7 +8,6 @@ function StyleGuidePreview({
   backgroundColour,
   simulationModes = [],
 }) {
-  const getContrast = (fg, bg) => chroma.contrast(fg, bg).toFixed(2);
   const getRGB = (hex) => chroma(hex).rgb().join(', ');
 
   const colourEntries = Object.entries(colours);


### PR DESCRIPTION
## Summary
- hook label for default background color to the color input
- remove an unused function from `StyleGuidePreview.jsx`
- call Vite using `node` so build/dev scripts work even if the binary lacks execute permission

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68417ef53b04833086ee5bb7907346ee