### PR TITLE
Add vitest tests for color conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# eLearning Palette Checker
+
+## Running Tests
+
+Install dependencies and run the test suite with:
+
+```bash
+npm test
+```
+
+This uses [vitest](https://vitest.dev/) as the test runner.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "node node_modules/vite/bin/vite.js",
     "build": "node node_modules/vite/bin/vite.js build",
     "lint": "eslint .",
-    "preview": "node node_modules/vite/bin/vite.js preview"
+    "preview": "node node_modules/vite/bin/vite.js preview",
+    "test": "vitest"
   },
   "dependencies": {
     "chroma-js": "^3.1.2",
@@ -26,6 +27,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",
     "vite": "^6.2.0",
-    "vite-plugin-bundle-analyzer": "^0.0.1"
+    "vite-plugin-bundle-analyzer": "^0.0.1",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/ExportOptions.jsx
+++ b/src/ExportOptions.jsx
@@ -1,5 +1,17 @@
 import html2pdf from 'html2pdf.js';
 
+export const hexToRgb = (hex) => {
+  try {
+    const [r, g, b] = hex
+      .replace('#', '')
+      .match(/.{1,2}/g)
+      .map((c) => parseInt(c, 16));
+    return `${r}, ${g}, ${b}`;
+  } catch {
+    return '0, 0, 0';
+  }
+};
+
 function ExportOptions({ colours }) {
   const exportPDF = () => {
     const element = document.getElementById('print-target');
@@ -69,18 +81,6 @@ function ExportOptions({ colours }) {
     link.href = URL.createObjectURL(blob);
     link.download = 'eLearnTint_palette.json';
     link.click();
-  };
-
-  const hexToRgb = (hex) => {
-    try {
-      const [r, g, b] = hex
-        .replace('#', '')
-        .match(/.{1,2}/g)
-        .map((c) => parseInt(c, 16));
-      return `${r}, ${g}, ${b}`;
-    } catch {
-      return '0, 0, 0';
-    }
   };
 
   return (

--- a/src/__tests__/exportOptions.test.js
+++ b/src/__tests__/exportOptions.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { hexToRgb } from '../ExportOptions.jsx';
+
+describe('hexToRgb', () => {
+  it('converts valid hex string to rgb string', () => {
+    expect(hexToRgb('#ffffff')).toBe('255, 255, 255');
+    expect(hexToRgb('#000000')).toBe('0, 0, 0');
+    expect(hexToRgb('#1a2b3c')).toBe('26, 43, 60');
+  });
+
+  it('falls back to 0,0,0 for invalid values', () => {
+    expect(hexToRgb('invalid')).toBe('0, 0, 0');
+    expect(hexToRgb('#zzz')).toBe('0, 0, 0');
+  });
+});


### PR DESCRIPTION
## Summary
- export `hexToRgb` and reuse in `ExportOptions`
- add vitest and `npm test` script
- write unit tests for `hexToRgb`
- document how to run tests in the README

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841863f433883309b9d256b3441427a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a README with project introduction and instructions for running tests.
- **Chores**
  - Added Vitest as a development dependency and a test script for running tests.
- **Refactor**
  - Made the color conversion utility available for reuse in other modules.
- **Tests**
  - Introduced tests to verify color conversion functionality, including handling of invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->